### PR TITLE
38 add styling mq for homepage

### DIFF
--- a/app/UI/Recommended.tsx
+++ b/app/UI/Recommended.tsx
@@ -47,7 +47,7 @@ export default function RecommendedMovies() {
 
   return (
     <div>
-      <h1 className="text-center text-white">Recommended for You</h1>
+      <h1 className="text-center text-white text-xl">Recommended for You</h1>
       <div>
         {recommendedMovies.map((movie) => (
           <Link href={`/movie/${movie.title}`} key={movie.title}>
@@ -56,7 +56,7 @@ export default function RecommendedMovies() {
               className="m-5 flex flex-col bg-white bg-opacity-50"
               key={movie.title}
             >
-              <h3 className="p-3 text-center">{movie.title}</h3>
+              <h3 className="p-3 text-center font-bold">{movie.title}</h3>
               <Image
                 src={movie.thumbnail}
                 height={100}

--- a/app/UI/Recommended.tsx
+++ b/app/UI/Recommended.tsx
@@ -47,7 +47,7 @@ export default function RecommendedMovies() {
 
   return (
     <div>
-      <h1 className="text-center text-white text-xl">Recommended for You</h1>
+      <h1 className="text-center text-xl text-white">Recommended for You</h1>
       <div>
         {recommendedMovies.map((movie) => (
           <Link href={`/movie/${movie.title}`} key={movie.title}>

--- a/app/UI/Trending.tsx
+++ b/app/UI/Trending.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { ChevronDoubleLeftIcon, ChevronDoubleRightIcon } from "@heroicons/react/24/outline";
+import Link from "next/link";
+import { useState } from "react";
+import Bookmark from "./bookmark";
+import movies from "../../movies.json";
+import Image from "next/image";
+
+export default function TrendingMovies() {
+    const [opacity, setOpacity] = useState(1);
+  const [currentSlide, setSlide] = useState(0);
+
+  const filteredMovies = movies.filter((movie) => movie.isTrending === true);
+  const length = filteredMovies.length;
+  const fadeDuration = 500;
+  const next = () => {
+    setOpacity(0);
+    setTimeout(() => {
+      setSlide(currentSlide === length - 1 ? 0 : currentSlide + 1);
+      setOpacity(1);
+    }, fadeDuration);
+  };
+  const previous = () => {
+    setOpacity(0);
+    setTimeout(() => {
+      setSlide(currentSlide === 0 ? length - 1 : currentSlide - 1);
+      setOpacity(1);
+    }, fadeDuration);
+  };
+
+  const currentMovie = filteredMovies[currentSlide];
+
+    return (
+        <div className="flex flex-row gap-2 md:hidden">
+        <div className="flex items-center justify-center">
+          <ChevronDoubleLeftIcon
+            onClick={previous}
+            className="size-7 cursor-pointer text-white hover:text-blue-400"
+          ></ChevronDoubleLeftIcon>
+        </div>
+        <div className="grow">
+          <Link href={`/movie/${currentMovie.title}`} key={currentMovie.title}>
+            <div
+              key={currentSlide}
+              /* eslint-disable-next-line tailwindcss/migration-from-tailwind-2, tailwindcss/no-custom-classname */
+              className="movie-thumbnail flex flex-col justify-center bg-white bg-opacity-50"
+              style={{ opacity: opacity }}
+            >
+              <h3 className="text-center">{currentMovie.title}</h3>
+              <Image
+                src={currentMovie.thumbnail}
+                height={100}
+                width={100}
+                alt={currentMovie.title}
+                style={{
+                  height: "100%",
+                  width: "auto",
+                  paddingRight: "20px",
+                  paddingLeft: "20px",
+                }}
+              />
+              <div className="flex flex-row justify-between p-5">
+                <p>{currentMovie.year}</p>
+                <div className="flex flex-row">
+                  <p>{currentMovie.rating}</p>
+                  <p>
+                    <Bookmark movieTitle={currentMovie.title} />
+                  </p>
+                </div>
+              </div>
+            </div>
+          </Link>
+        </div>
+        <div className="flex items-center justify-center">
+          <ChevronDoubleRightIcon
+            onClick={next}
+            className="size-7 cursor-pointer text-white hover:text-blue-400"
+          ></ChevronDoubleRightIcon>
+        </div>
+      </div>
+    );
+}

--- a/app/UI/TrendingBigScreen.tsx
+++ b/app/UI/TrendingBigScreen.tsx
@@ -1,9 +1,9 @@
 "use client"
 
-import { BookmarkIcon } from "@heroicons/react/24/outline";
 import Image from "next/image";
 import Link from "next/link";
 import movies from "../../movies.json";
+import Bookmark from "./bookmark";
 
 export default function TrendingMoviesBigScreen() { 
     const filteredMovies = movies.filter((movie) => movie.isTrending === true);
@@ -36,7 +36,7 @@ export default function TrendingMoviesBigScreen() {
               <div className="flex flex-row">
                 <p>{movie.rating}</p>
                 <p>
-                  <BookmarkIcon className="size-7 text-white" />
+                <Bookmark movieTitle={movie.title} />
                 </p>
               </div>
             </div>

--- a/app/UI/TrendingBigScreen.tsx
+++ b/app/UI/TrendingBigScreen.tsx
@@ -31,7 +31,7 @@ export default function TrendingMoviesBigScreen() {
                 paddingLeft: "20px",
               }}
             ></Image>
-            <div className="flex flex-row justify-between p-5">
+            <div className="flex flex-row justify-between px-7 py-5">
               <p>{movie.year}</p>
               <div className="flex flex-row">
                 <p>{movie.rating}</p>

--- a/app/UI/TrendingBigScreen.tsx
+++ b/app/UI/TrendingBigScreen.tsx
@@ -1,11 +1,48 @@
 "use client"
 
-export default function TrendingMoviesBigScreen() { 
-    const 
-    
-    return (
-        <div className="flex flex-col sm:hidden ">
+import { BookmarkIcon } from "@heroicons/react/24/outline";
+import Image from "next/image";
+import Link from "next/link";
+import movies from "../../movies.json";
 
-        </div>
+export default function TrendingMoviesBigScreen() { 
+    const filteredMovies = movies.filter((movie) => movie.isTrending === true);
+
+    return (
+        <div className="hidden grid-cols-2 justify-center gap-7 sm:hidden md:grid lg:grid-cols-3">
+ {filteredMovies.map((movie) => (
+        <Link href={`/movie/${movie.title}`} key={movie.title}>
+             
+          <div
+          /* eslint-disable-next-line tailwindcss/migration-from-tailwind-2, tailwindcss/no-custom-classname */
+            className="flex h-full flex-col justify-between rounded-md bg-white bg-opacity-50"
+            key={movie.title}
+          >
+            <h3 className="p-3 text-center font-bold">{movie.title}</h3>
+            <Image
+              src={movie.thumbnail}
+              height={100}
+              width={100}
+              alt={movie.title}
+              style={{
+                height: "100%",
+                width: "auto",
+                paddingRight: "20px",
+                paddingLeft: "20px",
+              }}
+            ></Image>
+            <div className="flex flex-row justify-between p-5">
+              <p>{movie.year}</p>
+              <div className="flex flex-row">
+                <p>{movie.rating}</p>
+                <p>
+                  <BookmarkIcon className="size-7 text-white" />
+                </p>
+              </div>
+            </div>
+          </div>
+        </Link>
+      ))}
+      </div>
     )
 }

--- a/app/UI/TrendingBigScreen.tsx
+++ b/app/UI/TrendingBigScreen.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+export default function TrendingMoviesBigScreen() { 
+    const 
+    
+    return (
+        <div className="flex flex-col sm:hidden ">
+
+        </div>
+    )
+}

--- a/app/UI/TrendingBigScreen.tsx
+++ b/app/UI/TrendingBigScreen.tsx
@@ -1,20 +1,19 @@
-"use client"
+"use client";
 
 import Image from "next/image";
 import Link from "next/link";
 import movies from "../../movies.json";
 import Bookmark from "./bookmark";
 
-export default function TrendingMoviesBigScreen() { 
-    const filteredMovies = movies.filter((movie) => movie.isTrending === true);
+export default function TrendingMoviesBigScreen() {
+  const filteredMovies = movies.filter((movie) => movie.isTrending === true);
 
-    return (
-        <div className="hidden grid-cols-2 justify-center gap-7 sm:hidden md:grid lg:grid-cols-3">
- {filteredMovies.map((movie) => (
+  return (
+    <div className="hidden grid-cols-2 justify-center gap-7 sm:hidden md:grid lg:grid-cols-3">
+      {filteredMovies.map((movie) => (
         <Link href={`/movie/${movie.title}`} key={movie.title}>
-             
           <div
-          /* eslint-disable-next-line tailwindcss/migration-from-tailwind-2, tailwindcss/no-custom-classname */
+            /* eslint-disable-next-line tailwindcss/migration-from-tailwind-2, tailwindcss/no-custom-classname */
             className="flex h-full flex-col justify-between rounded-md bg-white bg-opacity-50"
             key={movie.title}
           >
@@ -36,13 +35,13 @@ export default function TrendingMoviesBigScreen() {
               <div className="flex flex-row">
                 <p>{movie.rating}</p>
                 <p>
-                <Bookmark movieTitle={movie.title} />
+                  <Bookmark movieTitle={movie.title} />
                 </p>
               </div>
             </div>
           </div>
         </Link>
       ))}
-      </div>
-    )
+    </div>
+  );
 }

--- a/app/UI/TrendingMobile.tsx
+++ b/app/UI/TrendingMobile.tsx
@@ -1,6 +1,9 @@
-"use client"
+"use client";
 
-import { ChevronDoubleLeftIcon, ChevronDoubleRightIcon } from "@heroicons/react/24/outline";
+import {
+  ChevronDoubleLeftIcon,
+  ChevronDoubleRightIcon,
+} from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { useState } from "react";
 import Bookmark from "./bookmark";
@@ -8,7 +11,7 @@ import movies from "../../movies.json";
 import Image from "next/image";
 
 export default function TrendingMoviesMobile() {
-    const [opacity, setOpacity] = useState(1);
+  const [opacity, setOpacity] = useState(1);
   const [currentSlide, setSlide] = useState(0);
 
   const filteredMovies = movies.filter((movie) => movie.isTrending === true);
@@ -31,10 +34,10 @@ export default function TrendingMoviesMobile() {
 
   const currentMovie = filteredMovies[currentSlide];
 
-    return (
-        <div className="flex flex-col gap-4">
-            <h1 className="text-center text-xl text-white">Trending right now</h1>
-        <div className="flex flex-row gap-2 md:hidden">
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-center text-xl text-white">Trending right now</h1>
+      <div className="flex flex-row gap-2 md:hidden">
         <div className="flex items-center justify-center">
           <ChevronDoubleLeftIcon
             onClick={previous}
@@ -81,6 +84,6 @@ export default function TrendingMoviesMobile() {
           ></ChevronDoubleRightIcon>
         </div>
       </div>
-      </div>
-    );
+    </div>
+  );
 }

--- a/app/UI/TrendingMobile.tsx
+++ b/app/UI/TrendingMobile.tsx
@@ -62,7 +62,7 @@ export default function TrendingMoviesMobile() {
                   paddingLeft: "20px",
                 }}
               />
-              <div className="flex flex-row justify-between p-5">
+              <div className="flex flex-row justify-between px-7 py-5">
                 <p>{currentMovie.year}</p>
                 <div className="flex flex-row">
                   <p>{currentMovie.rating}</p>

--- a/app/UI/TrendingMobile.tsx
+++ b/app/UI/TrendingMobile.tsx
@@ -7,7 +7,7 @@ import Bookmark from "./bookmark";
 import movies from "../../movies.json";
 import Image from "next/image";
 
-export default function TrendingMovies() {
+export default function TrendingMoviesMobile() {
     const [opacity, setOpacity] = useState(1);
   const [currentSlide, setSlide] = useState(0);
 
@@ -32,6 +32,8 @@ export default function TrendingMovies() {
   const currentMovie = filteredMovies[currentSlide];
 
     return (
+        <div className="flex flex-col gap-4">
+            <h1 className="text-center text-white">Trending right now</h1>
         <div className="flex flex-row gap-2 md:hidden">
         <div className="flex items-center justify-center">
           <ChevronDoubleLeftIcon
@@ -78,6 +80,7 @@ export default function TrendingMovies() {
             className="size-7 cursor-pointer text-white hover:text-blue-400"
           ></ChevronDoubleRightIcon>
         </div>
+      </div>
       </div>
     );
 }

--- a/app/UI/TrendingMobile.tsx
+++ b/app/UI/TrendingMobile.tsx
@@ -33,7 +33,7 @@ export default function TrendingMoviesMobile() {
 
     return (
         <div className="flex flex-col gap-4">
-            <h1 className="text-center text-white">Trending right now</h1>
+            <h1 className="text-center text-white text-xl">Trending right now</h1>
         <div className="flex flex-row gap-2 md:hidden">
         <div className="flex items-center justify-center">
           <ChevronDoubleLeftIcon
@@ -49,7 +49,7 @@ export default function TrendingMoviesMobile() {
               className="movie-thumbnail flex flex-col justify-center bg-white bg-opacity-50"
               style={{ opacity: opacity }}
             >
-              <h3 className="text-center">{currentMovie.title}</h3>
+              <h3 className="text-center font-bold">{currentMovie.title}</h3>
               <Image
                 src={currentMovie.thumbnail}
                 height={100}

--- a/app/UI/TrendingMobile.tsx
+++ b/app/UI/TrendingMobile.tsx
@@ -33,7 +33,7 @@ export default function TrendingMoviesMobile() {
 
     return (
         <div className="flex flex-col gap-4">
-            <h1 className="text-center text-white text-xl">Trending right now</h1>
+            <h1 className="text-center text-xl text-white">Trending right now</h1>
         <div className="flex flex-row gap-2 md:hidden">
         <div className="flex items-center justify-center">
           <ChevronDoubleLeftIcon

--- a/app/UI/header.tsx
+++ b/app/UI/header.tsx
@@ -5,7 +5,7 @@ export default function Header() {
   return (
     <header className="flex justify-between bg-[#282525] p-4">
       <Link href="/">
-        <h1 className=" text-blue-400 ">Chick Flix</h1>
+        <h1 className=" text-xl text-blue-400">Chick Flix</h1>
       </Link>
 
       <Link href="/bookmarked">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import RecommendedMovies from "./UI/Recommended";
-import TrendingMovies from "./UI/Trending";
+import TrendingMoviesBigScreen from "./UI/TrendingBigScreen";
+import TrendingMoviesMobile from "./UI/TrendingMobile";
 import SearchBar from "./UI/searchbar";
 import "./global.css";
 
@@ -10,9 +11,8 @@ export default function Home() {
       <div className="flex justify-center">
         <SearchBar />
       </div>
-      <h1 className="text-center text-white">Trending right now</h1>
-
-      <TrendingMovies />
+      <TrendingMoviesMobile />
+      <TrendingMoviesBigScreen />
       <RecommendedMovies />
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,41 +1,9 @@
-"use client";
-
-import {
-  ChevronDoubleLeftIcon,
-  ChevronDoubleRightIcon,
-} from "@heroicons/react/24/outline";
-import Image from "next/image";
-import Link from "next/link";
-import { useState } from "react";
-import movies from "../movies.json";
 import RecommendedMovies from "./UI/Recommended";
-import Bookmark from "./UI/bookmark";
+import TrendingMovies from "./UI/Trending";
 import SearchBar from "./UI/searchbar";
 import "./global.css";
 
 export default function Home() {
-  const [opacity, setOpacity] = useState(1);
-  const [currentSlide, setSlide] = useState(0);
-
-  const filteredMovies = movies.filter((movie) => movie.isTrending === true);
-  const length = filteredMovies.length;
-  const fadeDuration = 500;
-  const next = () => {
-    setOpacity(0);
-    setTimeout(() => {
-      setSlide(currentSlide === length - 1 ? 0 : currentSlide + 1);
-      setOpacity(1);
-    }, fadeDuration);
-  };
-  const previous = () => {
-    setOpacity(0);
-    setTimeout(() => {
-      setSlide(currentSlide === 0 ? length - 1 : currentSlide - 1);
-      setOpacity(1);
-    }, fadeDuration);
-  };
-
-  const currentMovie = filteredMovies[currentSlide];
 
   return (
     <div className="flex flex-col gap-4">
@@ -44,53 +12,7 @@ export default function Home() {
       </div>
       <h1 className="text-center text-white">Trending right now</h1>
 
-      <div className="flex flex-row gap-2">
-        <div className="flex items-center justify-center">
-          <ChevronDoubleLeftIcon
-            onClick={previous}
-            className="size-7 cursor-pointer text-white hover:text-blue-400"
-          ></ChevronDoubleLeftIcon>
-        </div>
-        <div className="grow">
-          <Link href={`/movie/${currentMovie.title}`} key={currentMovie.title}>
-            <div
-              key={currentSlide}
-              /* eslint-disable-next-line tailwindcss/migration-from-tailwind-2, tailwindcss/no-custom-classname */
-              className="movie-thumbnail flex flex-col justify-center bg-white bg-opacity-50"
-              style={{ opacity: opacity }}
-            >
-              <h3 className="text-center">{currentMovie.title}</h3>
-              <Image
-                src={currentMovie.thumbnail}
-                height={100}
-                width={100}
-                alt={currentMovie.title}
-                style={{
-                  height: "100%",
-                  width: "auto",
-                  paddingRight: "20px",
-                  paddingLeft: "20px",
-                }}
-              />
-              <div className="flex flex-row justify-between p-5">
-                <p>{currentMovie.year}</p>
-                <div className="flex flex-row">
-                  <p>{currentMovie.rating}</p>
-                  <p>
-                    <Bookmark movieTitle={currentMovie.title} />
-                  </p>
-                </div>
-              </div>
-            </div>
-          </Link>
-        </div>
-        <div className="flex items-center justify-center">
-          <ChevronDoubleRightIcon
-            onClick={next}
-            className="size-7 cursor-pointer text-white hover:text-blue-400"
-          ></ChevronDoubleRightIcon>
-        </div>
-      </div>
+      <TrendingMovies />
       <RecommendedMovies />
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,6 @@ import SearchBar from "./UI/searchbar";
 import "./global.css";
 
 export default function Home() {
-
   return (
     <div className="flex flex-col gap-4">
       <div className="flex justify-center">


### PR DESCRIPTION
Made better responsiveness on homepage, mostly on "trending right now" since we yet don't have a carousel for "recommended". 

I split the trending right now into 2 diffrent files - one for mobile, one for ipad/desktop, I thougt it would be easier to find what we're looking for in that case. 

Mobile is a carousel view that (like it was everywhere before), in desktop and ipad the movies are lining up using a gridsystem. 

I also made the title for movies bold and made the header text (Chick Flix) and titles on homepage bigger. 